### PR TITLE
Enable Point in Time Recovery for DynamoDB tables

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -146,6 +146,8 @@ resources:
         ProvisionedThroughput:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true
     DevicesTable:
       Type: AWS::DynamoDB::Table
       Properties:
@@ -159,6 +161,8 @@ resources:
         ProvisionedThroughput:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true
     CiphersTable:
       Type: AWS::DynamoDB::Table
       Properties:
@@ -176,6 +180,8 @@ resources:
         ProvisionedThroughput:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true
     FoldersTable:
       Type: AWS::DynamoDB::Table
       Properties:
@@ -193,3 +199,5 @@ resources:
         ProvisionedThroughput:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true


### PR DESCRIPTION
Most regions now support PITR for DynamoDB tables. This allows you to restore how a table looked like in
any time period in the past 35 days. It essentially is also an automated rolling time window backup solution.

I might try to add some cron-based On-Demand backup triggers, but this covers 90% of use cases.

Costs are 20c/GB, which shouldn't yield any pricing surprises to users.