### PR TITLE
Hardcode constants until we figure out what the proper behavior is

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -41,6 +41,13 @@ default_cors: &default_cors
     allowMethods: "GET, POST, OPTIONS, PUT, DELETE"
 
 functions:
+  prelogin:
+    handler: src/prelogin.handler
+    events:
+      - http:
+          method: post
+          <<: *default_cors
+          path: api/accounts/prelogin
   login:
     handler: src/login.handler
     events:

--- a/src/prelogin.js
+++ b/src/prelogin.js
@@ -1,8 +1,10 @@
+const KDF_PBKDF2 = 0;
+
 export const handler = async (event, context, callback) => {
   callback(null, {
     statusCode: 200,
     body: JSON.stringify({
-      Kdf: 0,
+      Kdf: KDF_PBKDF2,
       KdfIterations: 5000,
     }),
   });

--- a/src/prelogin.js
+++ b/src/prelogin.js
@@ -1,0 +1,9 @@
+export const handler = async (event, context, callback) => {
+  callback(null, {
+    statusCode: 200,
+    body: JSON.stringify({
+      Kdf: 0,
+      KdfIterations: 5000,
+    }),
+  });
+};


### PR DESCRIPTION
Mock the constant repsonse from prelogin.  I think Kyle is going to add `/api/accounts/kdf` to allow editing this later, but I wanted a quick fix until we understand the full behavior.

Fixes #25 