### PR TITLE
Safeguard against DynamoDB table deletion

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -11,10 +11,10 @@ provider:
   memorySize: 256
   timeout: 10
   environment:
-    DEVICES_TABLE: ${self:service}-${opt:stage, self:provider.stage}-devices
-    USERS_TABLE: ${self:service}-${opt:stage, self:provider.stage}-users
-    CIPHERS_TABLE: ${self:service}-${opt:stage, self:provider.stage}-ciphers
-    FOLDERS_TABLE: ${self:service}-${opt:stage, self:provider.stage}-folders
+    DEVICES_TABLE: ${self:service}-${self:provider.stage}-devices
+    USERS_TABLE: ${self:service}-${self:provider.stage}-users
+    CIPHERS_TABLE: ${self:service}-${self:provider.stage}-ciphers
+    FOLDERS_TABLE: ${self:service}-${self:provider.stage}-folders
   iamRoleStatements:
     - Effect: Allow
       Action:
@@ -158,10 +158,18 @@ functions:
           <<: *default_cors
           path: /{fallback+}
 
+# When using the `prod` environment the DynamoDB tables will not be
+# delete when removing the Cloudformation stack. It's better to risk
+# having a forgotten table running than losing data
+tableDeletionPolicy:
+  prod: Retain
+  other: Delete
+
 resources:
   Resources:
     UsersTable:
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: ${self:tableDeletionPolicy.${self:provider.stage}, self.tableDeletionPolicy.other}
       Properties:
         TableName: ${self:provider.environment.USERS_TABLE}
         AttributeDefinitions:
@@ -177,6 +185,7 @@ resources:
           PointInTimeRecoveryEnabled: true
     DevicesTable:
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: ${self:tableDeletionPolicy.${self:provider.stage}, self.tableDeletionPolicy.other}
       Properties:
         TableName: ${self:provider.environment.DEVICES_TABLE}
         AttributeDefinitions:
@@ -192,6 +201,7 @@ resources:
           PointInTimeRecoveryEnabled: true
     CiphersTable:
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: ${self:tableDeletionPolicy.${self:provider.stage}, self.tableDeletionPolicy.other}
       Properties:
         TableName: ${self:provider.environment.CIPHERS_TABLE}
         AttributeDefinitions:
@@ -211,6 +221,7 @@ resources:
           PointInTimeRecoveryEnabled: true
     FoldersTable:
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: ${self:tableDeletionPolicy.${self:provider.stage}, self.tableDeletionPolicy.other}
       Properties:
         TableName: ${self:provider.environment.FOLDERS_TABLE}
         AttributeDefinitions:


### PR DESCRIPTION
If stage=prod, the DynamoDB table will be kept even after the stack is deleted