### PR TITLE
Disable signups

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -95,6 +95,8 @@ functions:
           path: api/accounts/keys
   register:
     handler: src/register.handler
+    environment:
+      DISABLE_USER_REGISTRATION: ${env:DISABLE_USER_REGISTRATION, 'false'}
     events:
       - http:
           method: post

--- a/src/register.js
+++ b/src/register.js
@@ -4,6 +4,11 @@ import { buildUserDocument } from './lib/bitwarden';
 
 export const handler = async (event, context, callback) => {
   console.log('Registration handler triggered', JSON.stringify(event, null, 2));
+  if (process.env.DISABLE_USER_REGISTRATION === 'true') {
+    callback(null, utils.validationError('Signups are not permitted'));
+    return;
+  }
+
   if (!event.body) {
     callback(null, utils.validationError('Missing request body'));
     return;


### PR DESCRIPTION
Support disable signups. refs #13 

```
# Disable Signup
DISABLE_USER_REGISTRATION=true serverless deploy

# Re-enable Signup
serverless deploy
or
DISABLE_USER_REGISTRATION=false serverless deploy
```

An error message that is when create new account if DISABLE_USER_REGISTRATION=true.
<img width="898" alt="disable_signups" src="https://user-images.githubusercontent.com/1042519/61177988-76dd7c80-a61d-11e9-9861-e6a01e359176.png">
