### PR TITLE
Switch to Node.js 10 runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "8.10.0"
+          "node": "10.16.3"
         }
       }
     ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "8"
+  - "10"
 
 before_install:
   - npm install -g serverless

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ I do however trust AWS infrastructure and with the traffic pattern needed for a 
 
 ## Development
 
-Javascript sources are transpiled using webpack and Babel to the AWS supported Node.js 8.10 target. Transpiling and bundling is part of the serverless deployment workflow.
+Javascript sources are transpiled using webpack and Babel to the AWS supported Node.js 10.x target. Transpiling and bundling is part of the serverless deployment workflow.
 
 The API is tested using blackbox integration tests against a fresh deployment on AWS. Simply run with `./test.sh` with AWS credentials configured. This will create a temporary stack in AWS, run the tests against the API and tear down the stack after completion.
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -12,7 +12,7 @@ plugins:
 provider:
   name: aws
   stage: ${opt:stage, 'prod'}
-  runtime: nodejs8.10
+  runtime: nodejs10.x
   memorySize: 256
   timeout: 10
   environment:


### PR DESCRIPTION
AWS is deprecating the Node.js 8 runtime, let's upgrade.

> Hello,
>
> We are contacting you as we have identified that your AWS Account currently has one or more Lambda functions using Node.js 8.10, which will reach its EOL at the end of 2019.
>
> What’s happening?
>
> The Node community has decided to end support for Node.js 8.x on December 31, 2019 [1]. From this date forward, Node.js 8.x will stop receiving bug fixes, security updates, and/or performance improvements. To ensure that your new and existing functions run on a supported and secure runtime, language runtimes that have reached their EOL are deprecated in AWS [2].
>
> For Node.js 8.x, there will be 2 stages to the runtime deprecation process:
>
> 1. Disable Function Create – Beginning January 6, 2020, customers will no longer be able to create functions using Node.js 8.10
>
> 2. Disable Function Update – Beginning February 3, 2020, customers will no longer be able to update functions using Node.js 8.10
>
> After this period, both function creation and updates will be disabled permanently. However, existing Node 8.x functions will still be available to process invocation events.
>
> What do I need to do?
>
> We encourage you to update all of your Node.js 8.10 functions to the newer available runtime version, Node.js 10.x[3]. You should test your functions for compatibility with the Node.js 10.x language version before applying changes to your production functions.