### PR TITLE
Enable API Gateway logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "AWS Serverless implementation of the Bitwarden API",
   "scripts": {
-    "test": "./test.sh"
+    "test": "./test.sh",
+    "deploy": "serverless deploy --region $REGION --stage prod"
   },
   "devDependencies": {
     "@babel/core": "^7.4.4",

--- a/serverless.yml
+++ b/serverless.yml
@@ -15,6 +15,8 @@ provider:
   runtime: nodejs10.x
   memorySize: 256
   timeout: 10
+  logs:
+    restApi: true
   environment:
     DEVICES_TABLE: ${self:service}-${self:provider.stage}-devices
     USERS_TABLE: ${self:service}-${self:provider.stage}-users


### PR DESCRIPTION
- Enable API Gateway logs.
- Add deploy command to `package.json` for convenience.

I wanted to enable logs for security reasons.