### PR TITLE
Added Endpoint type name example name

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ By default you will get a generated API gateway URL which is quite long. You can
 1. Issue an AWS ACM certificate for that domain in the `us-east-1` region (free). This will require you to add a verification CNAME or confirm a link on an e-mail going to that domain.
 1. Wait some time until the certificate activates (1 hour?)
 1. Go to the API Gateway console and under the Custom Domains section add a new mapping with your domain.
-1. Add the final CNAME in your DNS configuration, the target value will be in the format `<id>.cloudfront.net`
+1. Add the final CNAME in your DNS configuration, the target value will be in the following format:`<id>.cloudfront.net` for Edge-optimised or `<id>.execute-api.region.amazonaws.com`for Regional endpoint type
 
 ## Motivation
 


### PR DESCRIPTION
I was a bit confused when setting up my custom domain name for the generated API. As per the instructions in the readme, I was looking for my Gateway API endpoint ending with `.cloudfront.net`. The instructions may be clear for the more experienced AWS users but it might be a bit confusing for novice developers. 

P.S.: Thank you for the awesome script! I am very happy that I could shut down my EC2 bitwarden instance and have everything in a serverless form.