### PR TITLE
Fix for browser unlock and test

### DIFF
--- a/src/login.js
+++ b/src/login.js
@@ -3,6 +3,7 @@ import speakeasy from 'speakeasy';
 import * as utils from './lib/api_utils';
 import { User, Device } from './lib/models';
 import { regenerateTokens, hashesMatch, DEFAULT_VALIDITY } from './lib/bitwarden';
+import { KDF_PBKDF2, KDF_PBKDF2_ITERATIONS_DEFAULT } from './lib/crypto';
 
 export const handler = async (event, context, callback) => {
   console.log('Login handler triggered', JSON.stringify(event, null, 2));
@@ -157,6 +158,9 @@ export const handler = async (event, context, callback) => {
       refresh_token: tokens.refreshToken,
       Key: user.get('key'),
       PrivateKey: privateKey ? privateKey.toString('utf8') : null,
+      Kdf: KDF_PBKDF2,
+      KdfIterations: user.get('kdfIterations') || KDF_PBKDF2_ITERATIONS_DEFAULT,
+      ResetMasterPassword: false, // TODO: according to official server https://github.com/bitwarden/server/blob/01d4d97ef18637fa857195a7285fda092124a677/src/Core/IdentityServer/BaseRequestValidator.cs#L164
     }));
   } catch (e) {
     callback(null, utils.serverError('Internal error', e));

--- a/test/e2e/login.js
+++ b/test/e2e/login.js
@@ -183,6 +183,9 @@ describe("Login API", function () {
       expect(decoded.payload.email).to.equal(loginBody.username);
       expect(decoded.payload.nbf).to.be.below((new Date()).getTime() / 1000);
       expect(decoded.payload.exp).to.be.above((new Date()).getTime() / 1000);
+      expect(body.Kdf).to.equal(0);
+      expect(body.KdfIterations).to.equal(registrationBody.kdfIterations);
+      expect(body.ResetMasterPassword).to.equal(false);
 
       return chakram.wait();
     });
@@ -290,6 +293,9 @@ describe("Login API", function () {
         expect(body.refresh_token).to.equal(refreshToken);
         expect(body.access_token).not.to.equal(accessToken);
         expect(body.Key).to.equal(registrationBody.key);
+        expect(body.Kdf).to.equal(0);
+        expect(body.KdfIterations).to.equal(registrationBody.kdfIterations);
+        expect(body.ResetMasterPassword).to.equal(false);
 
         return chakram.wait();
       });


### PR DESCRIPTION
Fix unlock on desktop clients

By August, 4th there was a change in browser app which denies unlock if those fields were not retrieved at login phase

This condition is also verified at test code. 

This fixes #86 

Idea: https://github.com/dani-garcia/bitwarden_rs/issues/1084

